### PR TITLE
Added objectgroups to tiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ var STATE_START                = STATE_COUNT++;
 var STATE_MAP                  = STATE_COUNT++;
 var STATE_COLLECT_PROPS        = STATE_COUNT++;
 var STATE_COLLECT_ANIMATIONS   = STATE_COUNT++;
-var STATE_COLLECT_OBJECTGROUPS = STATE_COUNT++;
+var STATE_COLLECT_OBJECT_GROUPS = STATE_COUNT++;
 var STATE_WAIT_FOR_CLOSE       = STATE_COUNT++;
 var STATE_TILESET              = STATE_COUNT++;
 var STATE_TILE                 = STATE_COUNT++;
@@ -56,8 +56,8 @@ function parse(content, pathToFile, cb) {
   var propertiesNextState = 0;
   var animationsObject = null;
   var animationsNextState = 0;
-  var objectgroupsObject = null;
-  var objectgroupsNextState = 0;
+  var objectGroupsObject = null;
+  var objectGroupsNextState = 0;
   var tileIndex = 0;
   var tileSet = null;
   var tileSetNextState = 0;
@@ -208,7 +208,7 @@ function parse(content, pathToFile, cb) {
     },
     text: noop,
   };
-  states[STATE_COLLECT_OBJECTGROUPS] = {
+  states[STATE_COLLECT_OBJECT_GROUPS] = {
     opentag: function(tag) {
       if (tag.name === 'OBJECT') {
         object = new TmxObject();
@@ -221,14 +221,14 @@ function parse(content, pathToFile, cb) {
         object.rotation = float(tag.attributes.ROTATION, 0);
         object.gid = int(tag.attributes.GID);
         object.visible = bool(tag.attributes.VISIBLE, true);
-        objectgroupsObject.push(object);
+        objectGroupsObject.push(object);
         state = STATE_TILE_OBJECT;
       } else {
         waitForClose();
       }
     },
     closetag: function(name) {
-      state = objectgroupsNextState;
+      state = objectGroupsNextState;
     },
     text: noop
   };
@@ -251,7 +251,7 @@ function parse(content, pathToFile, cb) {
       } else if (tag.name === 'ANIMATION') {
         tile.animation = collectAnimations(tile.animations);
       } else if (tag.name === 'OBJECTGROUP') {
-        tile.objectgroup = collectObjectgroups(tile.objectgroups);
+        tile.objectGroup = collectObjectGroups(tile.objectGroups);
       } else {
         waitForClose();
       }
@@ -403,7 +403,7 @@ function parse(content, pathToFile, cb) {
       }
     },
     closetag: function(name) {
-      state = STATE_COLLECT_OBJECTGROUPS;
+      state = STATE_COLLECT_OBJECT_GROUPS;
     },
     text: noop
   };
@@ -611,10 +611,10 @@ function parse(content, pathToFile, cb) {
     state = STATE_COLLECT_ANIMATIONS;
   }
 
-  function collectObjectgroups(obj) {
-    objectgroupsObject = obj;
-    objectgroupsNextState = state;
-    state = STATE_COLLECT_OBJECTGROUPS;
+  function collectObjectGroups(obj) {
+    objectGroupsObject = obj;
+    objectGroupsNextState = state;
+    state = STATE_COLLECT_OBJECT_GROUPS;
   }
 
   function waitForClose() {
@@ -782,7 +782,7 @@ function Tile() {
   this.probability = null;
   this.properties = {};
   this.animations = [];
-  this.objectgroups = [];
+  this.objectGroups = [];
   this.image = null;
 }
 

--- a/index.js
+++ b/index.js
@@ -22,24 +22,26 @@ var FLIPPED_VERTICALLY_FLAG   = 0x40000000;
 var FLIPPED_DIAGONALLY_FLAG   = 0x20000000;
 
 var STATE_COUNT = 0;
-var STATE_START              = STATE_COUNT++;
-var STATE_MAP                = STATE_COUNT++;
-var STATE_COLLECT_PROPS      = STATE_COUNT++;
-var STATE_COLLECT_ANIMATIONS = STATE_COUNT++;
-var STATE_WAIT_FOR_CLOSE     = STATE_COUNT++;
-var STATE_TILESET            = STATE_COUNT++;
-var STATE_TILE               = STATE_COUNT++;
-var STATE_TILE_LAYER         = STATE_COUNT++;
-var STATE_OBJECT_LAYER       = STATE_COUNT++;
-var STATE_OBJECT             = STATE_COUNT++;
-var STATE_IMAGE_LAYER        = STATE_COUNT++;
-var STATE_TILE_DATA_XML      = STATE_COUNT++;
-var STATE_TILE_DATA_CSV      = STATE_COUNT++;
-var STATE_TILE_DATA_B64_RAW  = STATE_COUNT++;
-var STATE_TILE_DATA_B64_GZIP = STATE_COUNT++;
-var STATE_TILE_DATA_B64_ZLIB = STATE_COUNT++;
-var STATE_TERRAIN_TYPES      = STATE_COUNT++;
-var STATE_TERRAIN            = STATE_COUNT++;
+var STATE_START                = STATE_COUNT++;
+var STATE_MAP                  = STATE_COUNT++;
+var STATE_COLLECT_PROPS        = STATE_COUNT++;
+var STATE_COLLECT_ANIMATIONS   = STATE_COUNT++;
+var STATE_COLLECT_OBJECTGROUPS = STATE_COUNT++;
+var STATE_WAIT_FOR_CLOSE       = STATE_COUNT++;
+var STATE_TILESET              = STATE_COUNT++;
+var STATE_TILE                 = STATE_COUNT++;
+var STATE_TILE_LAYER           = STATE_COUNT++;
+var STATE_OBJECT_LAYER         = STATE_COUNT++;
+var STATE_OBJECT               = STATE_COUNT++;
+var STATE_TILE_OBJECT          = STATE_COUNT++;
+var STATE_IMAGE_LAYER          = STATE_COUNT++;
+var STATE_TILE_DATA_XML        = STATE_COUNT++;
+var STATE_TILE_DATA_CSV        = STATE_COUNT++;
+var STATE_TILE_DATA_B64_RAW    = STATE_COUNT++;
+var STATE_TILE_DATA_B64_GZIP   = STATE_COUNT++;
+var STATE_TILE_DATA_B64_ZLIB   = STATE_COUNT++;
+var STATE_TERRAIN_TYPES        = STATE_COUNT++;
+var STATE_TERRAIN              = STATE_COUNT++;
 
 function parse(content, pathToFile, cb) {
   var pathToDir = path.dirname(pathToFile);
@@ -54,6 +56,8 @@ function parse(content, pathToFile, cb) {
   var propertiesNextState = 0;
   var animationsObject = null;
   var animationsNextState = 0;
+  var objectgroupsObject = null;
+  var objectgroupsNextState = 0;
   var tileIndex = 0;
   var tileSet = null;
   var tileSetNextState = 0;
@@ -204,6 +208,30 @@ function parse(content, pathToFile, cb) {
     },
     text: noop,
   };
+  states[STATE_COLLECT_OBJECTGROUPS] = {
+    opentag: function(tag) {
+      if (tag.name === 'OBJECT') {
+        object = new TmxObject();
+        object.name = tag.attributes.NAME;
+        object.type = tag.attributes.TYPE;
+        object.x = int(tag.attributes.X);
+        object.y = int(tag.attributes.Y);
+        object.width = int(tag.attributes.WIDTH, 0);
+        object.height = int(tag.attributes.HEIGHT, 0);
+        object.rotation = float(tag.attributes.ROTATION, 0);
+        object.gid = int(tag.attributes.GID);
+        object.visible = bool(tag.attributes.VISIBLE, true);
+        objectgroupsObject.push(object);
+        state = STATE_TILE_OBJECT;
+      } else {
+        waitForClose();
+      }
+    },
+    closetag: function(name) {
+      state = objectgroupsNextState;
+    },
+    text: noop
+  };
   states[STATE_WAIT_FOR_CLOSE] = {
     opentag: function(tag) {
       waitForCloseOpenCount += 1;
@@ -220,8 +248,10 @@ function parse(content, pathToFile, cb) {
         collectProperties(tile.properties);
       } else if (tag.name === 'IMAGE') {
         tile.image = collectImage(tag);
-     } else if (tag.name === 'ANIMATION') {
+      } else if (tag.name === 'ANIMATION') {
         tile.animation = collectAnimations(tile.animations);
+      } else if (tag.name === 'OBJECTGROUP') {
+        tile.objectgroup = collectObjectgroups(tile.objectgroups);
       } else {
         waitForClose();
       }
@@ -346,6 +376,36 @@ function parse(content, pathToFile, cb) {
       state = STATE_OBJECT_LAYER;
     },
     text: noop,
+  };
+  states[STATE_TILE_OBJECT] = {
+    opentag: function(tag) {
+      switch (tag.name) {
+        case 'PROPERTIES':
+          collectProperties(object.properties);
+          break;
+        case 'ELLIPSE':
+          object.ellipse = true;
+          waitForClose();
+          break;
+        case 'POLYGON':
+          object.polygon = parsePoints(tag.attributes.POINTS);
+          waitForClose();
+          break;
+        case 'POLYLINE':
+          object.polyline = parsePoints(tag.attributes.POINTS);
+          waitForClose();
+          break;
+        case 'IMAGE':
+          object.image = collectImage(tag);
+          break;
+        default:
+          waitForClose();
+      }
+    },
+    closetag: function(name) {
+      state = STATE_COLLECT_OBJECTGROUPS;
+    },
+    text: noop
   };
   states[STATE_TILE_DATA_XML] = {
     opentag: function(tag) {
@@ -551,6 +611,12 @@ function parse(content, pathToFile, cb) {
     state = STATE_COLLECT_ANIMATIONS;
   }
 
+  function collectObjectgroups(obj) {
+    objectgroupsObject = obj;
+    objectgroupsNextState = state;
+    state = STATE_COLLECT_OBJECTGROUPS;
+  }
+
   function waitForClose() {
     waitForCloseNextState = state;
     state = STATE_WAIT_FOR_CLOSE;
@@ -716,6 +782,7 @@ function Tile() {
   this.probability = null;
   this.properties = {};
   this.animations = [];
+  this.objectgroups = [];
   this.image = null;
 }
 

--- a/test/collision.tmx
+++ b/test/collision.tmx
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="17" height="11" tilewidth="26" tileheight="26" nextobjectid="9">
+ <tileset firstgid="1" name="rocks_tileset" tilewidth="32" tileheight="32" tilecount="32">
+  <tileoffset x="-3" y="0"/>
+  <image source="rocks.png" width="128" height="256"/>
+  <tile id="0">
+   <objectgroup draworder="index">
+    <object id="0" x="0.5" y="3" width="24.5" height="24.9375"/>
+   </objectgroup>
+  </tile>
+  <tile id="1">
+   <objectgroup draworder="index">
+    <object id="0" x="12.0625" y="13.9375">
+     <ellipse/>
+    </object>
+   </objectgroup>
+  </tile>
+  <tile id="2">
+   <objectgroup draworder="index">
+    <object id="0" x="3.25" y="26">
+     <polygon points="0,0 1,-17.4375 13.3125,-18.375 22.375,-8.4375 22.0625,1.875 9.375,3.375"/>
+    </object>
+   </objectgroup>
+  </tile>
+  <tile id="4">
+   <objectgroup draworder="index">
+    <object id="0" x="6.1875" y="3.875">
+     <polyline points="0,0 14.5625,1.4375 12.9375,5.625 22.5625,7.4375 16.75,14.25 20.75,19.3125 13.375,23.125 2,22.3125 6.5,14.375 -3.875,15.3125 1.0625,7.6875 -2.3125,3.375 2.3125,4"/>
+    </object>
+   </objectgroup>
+  </tile>
+ </tileset>
+ <layer name="rocks" width="17" height="11">
+  <data encoding="base64" compression="zlib">
+   eJxjYBhcgIlK6pmJVItNHTJgJCBPSD8y4CfAxwcIhQs58tj8hss/hMKBGPsGGgAAWyQAPA==
+  </data>
+ </layer>
+</map>

--- a/test/test.js
+++ b/test/test.js
@@ -115,9 +115,9 @@ describe("tilesets", function() {
     var target = path.join(__dirname, "collision.tmx");
     tmx.parseFile(target, function(err, map) {
       if (err) return done(err);
-      assert.strictEqual(map.tileSets[0].tiles[0].objectgroups[0].width, 24);
-      assert.strictEqual(map.tileSets[0].tiles[1].objectgroups[0].ellipse, true);
-      assert.strictEqual(map.tileSets[0].tiles[2].objectgroups[0].y, 26);
+      assert.strictEqual(map.tileSets[0].tiles[0].objectGroups[0].width, 24);
+      assert.strictEqual(map.tileSets[0].tiles[1].objectGroups[0].ellipse, true);
+      assert.strictEqual(map.tileSets[0].tiles[2].objectGroups[0].y, 26);
       done();
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -100,7 +100,7 @@ describe("tilesets", function() {
       done();
     });
   });
-  it("animation in tilesets", function(done) {
+  it("animated tiles", function(done) {
     var target = path.join(__dirname, "animation.tmx");
     tmx.parseFile(target, function(err, map) {
       if (err) return done(err);
@@ -108,6 +108,16 @@ describe("tilesets", function() {
       assert.strictEqual(map.height, 11);
       assert.strictEqual(map.layers[0].name, "fire");
       assert.strictEqual(map.tileSets[0].tiles[0].animations[5].duration, "100");
+      done();
+    });
+  });
+  it("objectgroups in tiles", function(done) {
+    var target = path.join(__dirname, "collision.tmx");
+    tmx.parseFile(target, function(err, map) {
+      if (err) return done(err);
+      assert.strictEqual(map.tileSets[0].tiles[0].objectgroups[0].width, 24);
+      assert.strictEqual(map.tileSets[0].tiles[1].objectgroups[0].ellipse, true);
+      assert.strictEqual(map.tileSets[0].tiles[2].objectgroups[0].y, 26);
       done();
     });
   });


### PR DESCRIPTION
Added objectgroups to tiles, which are use by the Tiled Map collision editor. Also added the corresponig test case.
Maybe this can be refactored with object layers to keep it more DRY, but that is up to you :)