### PR TITLE
Parse typed properties correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,10 @@ function parse(content, pathToFile, cb) {
   states[STATE_COLLECT_PROPS] = {
     opentag: function(tag) {
       if (tag.name === 'PROPERTY') {
-        propertiesObject[tag.attributes.NAME] = tag.attributes.VALUE;
+        propertiesObject[tag.attributes.NAME] = parseProperty(
+          tag.attributes.VALUE,
+          tag.attributes.TYPE
+        );
       }
       waitForClose();
     },
@@ -705,6 +708,20 @@ function parsePoints(str) {
       y: xy[1],
     };
   });
+}
+
+function parseProperty(value, type) {
+  switch (type) {
+    case 'int':
+      return parseInt(value, 10);
+    case 'float':
+      return parseFloat(value, 2);
+    case 'bool':
+      return value === 'true';
+    default:
+      return value;
+  }
+
 }
 
 function noop() {}

--- a/test/object-properties-csv.tmx
+++ b/test/object-properties-csv.tmx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.0" orientation="orthogonal" width="200" height="70" tilewidth="16" tileheight="16">
+ <tileset firstgid="1" source="tiles.tsx"/>
+ <objectgroup name="Object Layer 1" width="200" height="70">
+  <object type="Button" gid="14" x="704" y="96">
+   <properties>
+    <property name="color" value="green"/>
+    <property name="growing" type="bool" value="true"/>
+    <property name="dead" type="bool" value="false"/>
+    <property name="height" type="int" value="2"/>
+    <property name="timer" type="int" value="-2"/>
+    <property name="pi" type="float" value="3.1400000000000001"/>
+   </properties>
+  </object>
+</map>

--- a/test/test.js
+++ b/test/test.js
@@ -173,6 +173,44 @@ describe("implicit tiles", function() {
   });
 });
 
+describe("custom property types", function() {
+  it("parses strings correctly", function(done) {
+    var target = path.join(__dirname, "object-properties-csv.tmx");
+    tmx.parseFile(target, function(err, map) {
+      if (err) return done(err);
+
+      var object = map.layers[0].objects[0];
+      assert.strictEqual(object.properties.color, "green");
+      done();
+    });
+  });
+
+  it("parses booleans correctly", function(done) {
+    var target = path.join(__dirname, "object-properties-csv.tmx");
+    tmx.parseFile(target, function(err, map) {
+      if (err) return done(err);
+
+      var object = map.layers[0].objects[0];
+      assert.strictEqual(object.properties.growing, true);
+      assert.strictEqual(object.properties.dead, false);
+      done();
+    });
+  });
+
+  it("parses numbers correctly", function(done) {
+    var target = path.join(__dirname, "object-properties-csv.tmx");
+    tmx.parseFile(target, function(err, map) {
+      if (err) return done(err);
+
+      var object = map.layers[0].objects[0];
+      assert.strictEqual(object.properties.height, 2);
+      assert.strictEqual(object.properties.timer, -2);
+      assert.strictEqual(object.properties.pi, 3.14);
+      done();
+    });
+  });
+});
+
 function generateEncodingTypeTest(filename) {
   var target = path.join(__dirname, filename);
   return function(done) {


### PR DESCRIPTION
I found that my .tmx files would have property types defined:

<img width="327" alt="skjermbilde 2016-07-24 kl 23 22 58" src="https://cloud.githubusercontent.com/assets/874365/17086548/9835545e-51f5-11e6-85f3-4debae5da4dc.png">

These wouldn't be parsed correctly; I would always get a string. And I think `tmx-parser` should handle that concern.

I've added tests for the case, all tests pass on my machine and `jshint` passes.

Any thoughts?
